### PR TITLE
Allow Setting the Initial State of the Drawable in XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ app:mm_transformDuration="integer" // Transformation animation duration
 app:mm_scale="integer"             // Scale factor of drawable
 app:mm_strokeWidth="integer"       // Stroke width of icons (can only be 1, 2 or 3)
 app:mm_rtlEnabled="boolean"        // Enabled RTL layout support (flips all drawables)
+app:mm_iconState="enum"            // Set the intial state of the drawable (burger, arrow, x or check)
 ```
 
 ### MaterialMenuIcon

--- a/library/src/main/java/com/balysv/materialmenu/MaterialMenuView.java
+++ b/library/src/main/java/com/balysv/materialmenu/MaterialMenuView.java
@@ -69,9 +69,26 @@ public class MaterialMenuView extends View implements MaterialMenu {
             int transformDuration = attr.getInteger(R.styleable.MaterialMenuView_mm_transformDuration, DEFAULT_TRANSFORM_DURATION);
             Stroke stroke = Stroke.valueOf(attr.getInteger(R.styleable.MaterialMenuView_mm_strokeWidth, 0));
             boolean rtlEnabled = attr.getBoolean(R.styleable.MaterialMenuView_mm_rtlEnabled, false);
+            int state = attr.getInt(R.styleable.MaterialMenuView_mm_iconState, 0);
+
+            switch (state) {
+                case 0:
+                    currentState = IconState.BURGER;
+                    break;
+                case 1:
+                    currentState = IconState.ARROW;
+                    break;
+                case 2:
+                    currentState = IconState.X;
+                    break;
+                case 3:
+                    currentState = IconState.CHECK;
+                    break;
+            }
 
             drawable = new MaterialMenuDrawable(context, color, stroke, scale, transformDuration);
 
+            drawable.setIconState(currentState);
             drawable.setVisible(visible);
             drawable.setRTLEnabled(rtlEnabled);
         } finally {

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -7,5 +7,11 @@
         <attr name="mm_transformDuration" format="integer"/>
         <attr name="mm_strokeWidth" format="integer"/>
         <attr name="mm_rtlEnabled" format="boolean"/>
+        <attr name="mm_iconState" format="enum">
+            <enum name="burger" value="0" />
+            <enum name="arrow" value="1" />
+            <enum name="x" value="2" />
+            <enum name="check" value="3" />
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Small change to allow user to choose the initial state of the drawable via xml rather than having to change it in the code later on.